### PR TITLE
added  better run commands for deno

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch --allow-net --allow-read src/main.ts",
+    "test": "deno run --watch --allow-net --allow-read --allow-env src/main_test.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"


### PR DESCRIPTION
deno can use run commands to integrate multiple security checks so you dont have to authorize everything when you run your project, it can also make it easyer by insted of writing the full filepath you can insted write `deno run dev` (dev is just used as an example in my showcase here you can use what you want just keep in mind that what you write is what you have to type in after the deno run command to run your designated project file)